### PR TITLE
Include .json extension in MANIFEST.in.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,5 @@ include CHANGELOG.rst
 include requirements.txt
 include setup.cfg
 
-recursive-include data *
+recursive-include data *.json
 recursive-include docs *


### PR DESCRIPTION
Not doing so causes nothing in the data directory to be included in the
distribution.

Fixes #2265.