### PR TITLE
Access files as setuptools pkg_resource

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,25 @@
+import json
+from pkg_resources import resource_filename
+
+__title__ = 'safety-db'
+__version__ = '2020.4.14'
+__author__ = 'Justin Womersley <support@pyup.io>'
+__copyright__ = '2016-2017 PyUp'
+__license__ = 'Attribution-NonCommercial-ShareAlike 4.0 International'
+__all__ = (
+    'INSECURE',
+    'INSECURE_FULL',
+)
+
+with open(resource_filename("safety_db", "insecure.json")) as __f:
+    try:
+        INSECURE = json.loads(__f.read())
+    except ValueError as e:
+        INSECURE = []
+
+
+with open(resource_filename("safety_db", "insecure_full.json")) as __f:
+    try:
+        INSECURE_FULL = json.loads(__f.read())
+    except ValueError as e:
+        INSECURE_FULL = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 packaging
 parameterized
+setuptools


### PR DESCRIPTION
from `data/__init__.py`:

```
with open("data/insecure.json") as __f:
```

That open is relative to your working directory, the reason it works for testing is that folder data is in the root of your package. The proper way to access this file is with `pkg_resources` from setuptools as a `resource_filename`.

