### PR TITLE
Load JSON using importlib.resources

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,4 +1,5 @@
 import json
+from importlib.resources import read_text
 
 __title__ = 'safety-db'
 __version__ = '2021.7.17'
@@ -10,15 +11,13 @@ __all__ = (
     'INSECURE_FULL',
 )
 
-with open("data/insecure.json") as __f:
-    try:
-        INSECURE = json.loads(__f.read())
-    except ValueError as e:
-        INSECURE = []
+try:
+    INSECURE = json.loads(read_text(__package__, "insecure.json"))
+except ValueError as e:
+    INSECURE = []
 
 
-with open("data/insecure_full.json") as __f:
-    try:
-        INSECURE_FULL = json.loads(__f.read())
-    except ValueError as e:
-        INSECURE_FULL = []
+try:
+    INSECURE_FULL = json.loads(read_text(__package__, "insecure_full.json"))
+except ValueError as e:
+    INSECURE_FULL = []

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,10 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     classifiers=[
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Environment :: Web Environment",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
@@ -54,4 +54,5 @@ setup(
     install_requires=[],
     tests_require=tests_require,
     include_package_data=True,
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
This is a updated fix for https://github.com/pyupio/safety-db/issues/2308 and supersedes https://github.com/pyupio/safety-db/pull/2309

It uses importlib.resources which means dropping support for python 3.6 and below.

I tested using the following commands:
```
> python.exe .\setup.py sdist
> python.exe -m pip install .\dist\safety-db-2021.7.17.tar.gz
> python.exe
>>> import safety_db
>>> dir(safety_db)
['INSECURE', 'INSECURE_FULL', '__all__', '__author__', '__builtins__', '__cached__', '__copyright__', '__doc__', '__file__', '__license__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__title__', '__version__', 'json', 'read_text']
>>> len(safety_db.INSECURE)
1787
```